### PR TITLE
Update environment.yml with conda-forge channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,6 @@ dependencies:
   - cchardet
   - geopandas
   - einops
+
+channels:
+  - conda-forge


### PR DESCRIPTION
If the user did not add the conda-forge channel to his/her channels, the user will get the following error:

_PackagesNotFoundError: The following packages are not available from current channels:_

  _- einops_